### PR TITLE
Eng 1389 - Authorization switch for pardot api

### DIFF
--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -72,12 +72,15 @@ class PardotAPI(object):
         """
         if params is None:
             params = {}
-        params.update({'user_key': self.user_key, 'api_key': self.api_key, 'format': 'json'})
+        params.update({'format': 'json'})
+        headers = {
+            'Authorization': f'Bearer {self.api_key}'
+        }
         if data is None:
             data = {}
         try:
             self._check_auth(object_name=object_name)
-            request = requests.post(self._full_path(object_name, self.version, path), params=params, data=data)
+            request = requests.post(self._full_path(object_name, self.version, path), params=params, data=data, headers=headers)
             response = self._check_response(request)
             return response
         except PardotAPIError as err:
@@ -95,10 +98,13 @@ class PardotAPI(object):
         """
         if params is None:
             params = {}
-        params.update({'user_key': self.user_key, 'api_key': self.api_key, 'format': 'json'})
+        params.update({'format': 'json'})
+        headers = {
+            'Authorization': f'Bearer {self.api_key}'
+        }
         try:
             self._check_auth(object_name=object_name)
-            request = requests.get(self._full_path(object_name, self.version, path), params=params)
+            request = requests.get(self._full_path(object_name, self.version, path), params=params, headers=headers)
             response = self._check_response(request)
             return response
         except PardotAPIError as err:

--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -177,5 +177,5 @@ class PardotAPI(object):
     def _build_auth_header(self):
         if not self.user_key or not self.api_key:
             raise Exception('Cannot build Authorization header. user or api key is empty')
-        auth_string = 'Pardot api_key={self.api_key}, user_key={self.user_key}'
+        auth_string = f'Pardot api_key={self.api_key}, user_key={self.user_key}'
         return {'Authorization': auth_string}


### PR DESCRIPTION
Pardot is upgrading their authorization so credentials aren't put through query parameters.

Authorization is now done as follows: http://developer.pardot.com#sample-get-request

This is implemented the same way as the repo we forked from.