### PR TITLE
First authentication request was using authentication - failing

### DIFF
--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -165,7 +165,7 @@ class PardotAPI(object):
          False if authentication fails.
         """
         try:
-            response = requests.post(self._full_path('login', self.version), params={'email': self.email, 'password': self.password})
+            response = requests.post(self._full_path('login', self.version), data={'email': self.email, 'password': self.password})
             auth = self._check_response(request)
             self.api_key = auth.get('api_key')
             if self.api_key is not None:

--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -165,8 +165,15 @@ class PardotAPI(object):
          False if authentication fails.
         """
         try:
-            response = requests.post(self._full_path('login', self.version), data={'email': self.email, 'password': self.password})
-            auth = self._check_response(request)
+            login_data = {
+                'email': self.email,
+                'password': self.password,
+                'user_key': self.user_key,
+                'api_key': self.api_key,
+                'format': 'json'
+            }
+            response = requests.post(self._full_path('login', self.version), data=login_data)
+            auth = self._check_response(response)
             self.api_key = auth.get('api_key')
             if self.api_key is not None:
                 return True

--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -165,7 +165,8 @@ class PardotAPI(object):
          False if authentication fails.
         """
         try:
-            auth = self.post('login', params={'email': self.email, 'password': self.password})
+            response = requests.post(self._full_path('login', self.version), params=params={'email': self.email, 'password': self.password})
+            auth = self._check_response(request)
             self.api_key = auth.get('api_key')
             if self.api_key is not None:
                 return True

--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -165,7 +165,7 @@ class PardotAPI(object):
          False if authentication fails.
         """
         try:
-            response = requests.post(self._full_path('login', self.version), params=params={'email': self.email, 'password': self.password})
+            response = requests.post(self._full_path('login', self.version), params={'email': self.email, 'password': self.password})
             auth = self._check_response(request)
             self.api_key = auth.get('api_key')
             if self.api_key is not None:


### PR DESCRIPTION
The first request to authenticate was using the class method for post, which needed authentication which would exception out.

Sentry here: https://sentry.io/organizations/bungalow/issues/946422113